### PR TITLE
Add an option to print scorecards on A6 paper.

### DIFF
--- a/public/wcif-extensions/CompetitionConfig.json
+++ b/public/wcif-extensions/CompetitionConfig.json
@@ -28,6 +28,11 @@
     "printStations": {
       "description": "A flag indicating whether competitors should have printed stations on their scorecards in generated PDF documents.",
       "type": "boolean"
+    },
+    "pageSize": {
+      "description": "The size of paper that should be used for printing scorecards.",
+      "type": "string",
+      "enum": ["a4", "a6"]
     }
   },
   "required": ["localNamesFirst", "scorecardsBackgroundUrl", "competitorsSortingRule", "noTasksForNewcomers", "tasksForOwnEventsOnly"]

--- a/public/wcif-extensions/CompetitionConfig.json
+++ b/public/wcif-extensions/CompetitionConfig.json
@@ -29,7 +29,7 @@
       "description": "A flag indicating whether competitors should have printed stations on their scorecards in generated PDF documents.",
       "type": "boolean"
     },
-    "pageSize": {
+    "scorecardPaperSize": {
       "description": "The size of paper that should be used for printing scorecards.",
       "type": "string",
       "enum": ["a4", "a6"]

--- a/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
+++ b/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
@@ -43,6 +43,17 @@ const competitorsSortingRules = [
   },
 ];
 
+const paperSizes = [
+  {
+    id: 'a4',
+    name: 'Four scorecards per page (A4 paper)',
+  },
+  {
+    id: 'a6',
+    name: 'One scorecard per page (A6 paper)',
+  },
+];
+
 const GeneralConfig = ({ wcif, onWcifChange }) => {
   const handlePropertyChange = (property, value) => {
     onWcifChange(
@@ -71,6 +82,7 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
     localNamesFirst,
     scorecardsBackgroundUrl,
     printStations,
+    paperSize,
   } = getExtensionData('CompetitionConfig', wcif);
 
   return (
@@ -137,6 +149,25 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
           <Typography variant="h5" gutterBottom>
             Printing
           </Typography>
+          <Grid item>
+            <FormControl fullWidth>
+              <InputLabel htmlFor="paper-size">Page Size</InputLabel>
+              <Select
+                value={paperSize}
+                onChange={handleTextFieldChange}
+                inputProps={{
+                  name: 'paperSize',
+                  id: 'paper-size',
+                }}
+              >
+                {paperSizes.map(({ id, name }) => (
+                  <MenuItem value={id} key={id}>
+                    {name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
           <FormControlLabel
             control={
               <Checkbox

--- a/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
+++ b/src/components/Competition/ConfigManager/GeneralConfig/GeneralConfig.js
@@ -43,7 +43,7 @@ const competitorsSortingRules = [
   },
 ];
 
-const paperSizes = [
+const scorecardPaperSizes = [
   {
     id: 'a4',
     name: 'Four scorecards per page (A4 paper)',
@@ -82,7 +82,7 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
     localNamesFirst,
     scorecardsBackgroundUrl,
     printStations,
-    paperSize,
+    scorecardPaperSize,
   } = getExtensionData('CompetitionConfig', wcif);
 
   return (
@@ -151,16 +151,18 @@ const GeneralConfig = ({ wcif, onWcifChange }) => {
           </Typography>
           <Grid item>
             <FormControl fullWidth>
-              <InputLabel htmlFor="paper-size">Page Size</InputLabel>
+              <InputLabel htmlFor="scorecard-paper-size">
+                Scorecard Paper Size
+              </InputLabel>
               <Select
-                value={paperSize}
+                value={scorecardPaperSize}
                 onChange={handleTextFieldChange}
                 inputProps={{
-                  name: 'paperSize',
-                  id: 'paper-size',
+                  name: 'scorecardPaperSize',
+                  id: 'scorecard-paper-size',
                 }}
               >
-                {paperSizes.map(({ id, name }) => (
+                {scorecardPaperSizes.map(({ id, name }) => (
                   <MenuItem value={id} key={id}>
                     {name}
                   </MenuItem>

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -17,21 +17,34 @@ import { sortedGroupActivitiesWithSize } from '../groups';
 import { hasAssignment } from '../assignments';
 
 /* See: https://github.com/bpampuch/pdfmake/blob/3da11bd8148b190808b06f7bc27883102bf82917/src/standardPageSizes.js#L10 */
-const pageWidth = 595.28;
-const pageHeight = 841.89;
+const paperSizes = {
+  a4: {
+    pageWidth: 595.28,
+    pageHeight: 841.89,
+    scorecardsPerRow: 2,
+    scorecardsPerPage: 4,
+  },
+  a6: {
+    pageWidth: 297.64,
+    pageHeight: 419.53,
+    scorecardsPerRow: 1,
+    scorecardsPerPage: 1,
+  },
+};
 const scorecardMargin = 20;
 
 const maxAttemptCountByFormat = { '1': 1, '2': 2, '3': 3, m: 3, a: 5 };
 
 export const downloadScorecards = (wcif, rounds) => {
-  const { scorecardsBackgroundUrl } = getExtensionData(
+  const { scorecardsBackgroundUrl, paperSize } = getExtensionData(
     'CompetitionConfig',
     wcif
   );
   getImageDataUrl(scorecardsBackgroundUrl).then(imageData => {
     const pdfDefinition = scorecardsPdfDefinition(
       scorecards(wcif, rounds),
-      imageData
+      imageData,
+      paperSize
     );
     pdfMake.createPdf(pdfDefinition).download(`${wcif.id}-scorecards.pdf`);
   });
@@ -53,55 +66,77 @@ export const downloadBlankScorecards = wcif => {
   });
 };
 
-const scorecardsPdfDefinition = (scorecardList, imageData) => ({
-  background: [
-    ...(imageData === null
-      ? []
-      : [
-          /* Determined empirically to fit results table. */
-          { x: 60, y: 170 },
-          { x: 360, y: 170 },
-          { x: 60, y: 590 },
-          { x: 360, y: 590 },
-        ].map(absolutePosition => ({ absolutePosition, image: imageData }))),
-    {
-      canvas: [
-        cutLine({
-          x1: scorecardMargin,
-          y1: pageHeight / 2,
-          x2: pageWidth - scorecardMargin,
-          y2: pageHeight / 2,
-        }),
-        cutLine({
-          x1: pageWidth / 2,
-          y1: scorecardMargin,
-          x2: pageWidth / 2,
-          y2: pageHeight - scorecardMargin,
-        }),
-      ],
+const scorecardsPdfDefinition = (scorecardList, imageData, paperSize) => {
+  const {
+    pageWidth,
+    pageHeight,
+    scorecardsPerRow,
+    scorecardsPerPage,
+  } = paperSizes[paperSize];
+  const imagePositions = [
+    /* Determined empirically to fit results table. */
+    { x: 60, y: 170 },
+    { x: 360, y: 170 },
+    { x: 60, y: 590 },
+    { x: 360, y: 590 },
+  ].slice(0, scorecardsPerPage);
+  const cutLines =
+    scorecardsPerPage === 4
+      ? {
+          canvas: [
+            cutLine({
+              x1: scorecardMargin,
+              y1: pageHeight / 2,
+              x2: pageWidth - scorecardMargin,
+              y2: pageHeight / 2,
+            }),
+            cutLine({
+              x1: pageWidth / 2,
+              y1: scorecardMargin,
+              x2: pageWidth / 2,
+              y2: pageHeight - scorecardMargin,
+            }),
+          ],
+        }
+      : {};
+
+  return {
+    background: [
+      ...(imageData === null
+        ? []
+        : imagePositions.map(absolutePosition => ({
+            absolutePosition,
+            image: imageData,
+          }))),
+      cutLines,
+    ],
+    pageSize: { width: pageWidth, height: pageHeight },
+    pageMargins: [scorecardMargin, scorecardMargin],
+    content: {
+      layout: {
+        /* Outer margin is done using pageMargins, we use padding for the remaining inner margins. */
+        paddingLeft: i => (i % scorecardsPerRow === 0 ? 0 : scorecardMargin),
+        paddingRight: i =>
+          i % scorecardsPerRow === scorecardsPerRow - 1 ? 0 : scorecardMargin,
+        paddingTop: i => (i % scorecardsPerRow === 0 ? 0 : scorecardMargin),
+        paddingBottom: i =>
+          i % scorecardsPerRow === scorecardsPerRow - 1 ? 0 : scorecardMargin,
+        /* Get rid of borders. */
+        hLineWidth: () => 0,
+        vLineWidth: () => 0,
+      },
+      table: {
+        widths: ['*'] * scorecardsPerRow,
+        /* Page height minus vertical margins, divided by cards / row. */
+        heights:
+          (pageHeight - 2 * scorecardsPerRow * scorecardMargin) /
+          scorecardsPerRow,
+        dontBreakRows: true,
+        body: chunk(scorecardList, scorecardsPerRow),
+      },
     },
-  ],
-  pageMargins: [scorecardMargin, scorecardMargin],
-  content: {
-    layout: {
-      /* Outer margin is done using pageMargins, we use padding for the remaining inner margins. */
-      paddingLeft: i => (i % 2 === 0 ? 0 : scorecardMargin),
-      paddingRight: i => (i % 2 === 0 ? scorecardMargin : 0),
-      paddingTop: i => (i % 2 === 0 ? 0 : scorecardMargin),
-      paddingBottom: i => (i % 2 === 0 ? scorecardMargin : 0),
-      /* Get rid of borders. */
-      hLineWidth: () => 0,
-      vLineWidth: () => 0,
-    },
-    table: {
-      widths: ['*', '*'],
-      /* A4 page height minus vertical margins, divided into a half. */
-      heights: (pageHeight - 4 * scorecardMargin) / 2,
-      dontBreakRows: true,
-      body: chunk(scorecardList, 2),
-    },
-  },
-});
+  };
+};
 
 const cutLine = properties => ({
   ...properties,
@@ -112,7 +147,7 @@ const cutLine = properties => ({
 });
 
 const scorecards = (wcif, rounds) => {
-  const { localNamesFirst, printStations } = getExtensionData(
+  const { localNamesFirst, printStations, paperSize } = getExtensionData(
     'CompetitionConfig',
     wcif
   );
@@ -137,12 +172,18 @@ const scorecards = (wcif, rounds) => {
           competitor,
           localNamesFirst,
           printStations,
+          paperSize,
         })
       );
-      const scorecardsOnLastPage = groupScorecards.length % 4;
-      return scorecardsOnLastPage === 0
+      const { scorecardsPerPage } = paperSizes[paperSize];
+      const scorecardsOnLastPage = groupScorecards.length % scorecardsPerPage;
+      const extraScorecards =
+        scorecardsOnLastPage === scorecardsPerPage
+          ? 0
+          : scorecardsPerPage - scorecardsOnLastPage;
+      return extraScorecards === 0
         ? groupScorecards
-        : groupScorecards.concat(times(4 - scorecardsOnLastPage, () => ({})));
+        : groupScorecards.concat(times(extraScorecards, () => ({})));
     });
   });
 };
@@ -185,8 +226,12 @@ const blankScorecards = wcif => {
   const attemptCounts = flatMap(wcif.events, event => event.rounds).map(
     round => maxAttemptCountByFormat[round.format]
   );
+  const { paperSize } = getExtensionData('CompetitionConfig', wcif);
+  const { scorecardsPerPage } = paperSizes[paperSize];
   return flatMap(uniq(attemptCounts), attemptCount =>
-    times(4, () => scorecard({ competitionName: wcif.name, attemptCount }))
+    times(scorecardsPerPage, () =>
+      scorecard({ competitionName: wcif.name, attemptCount, paperSize })
+    )
   );
 };
 
@@ -200,11 +245,14 @@ const scorecard = ({
   competitor = { name: ' ', registrantId: ' ' },
   localNamesFirst = false,
   printStations,
+  paperSize,
 }) => {
   const { eventId, roundNumber, groupNumber } = activityCode
     ? parseActivityCode(activityCode)
     : {};
   const { cutoff, timeLimit } = round || {};
+  const { pageWidth, scorecardsPerRow } = paperSizes[paperSize];
+  const scorecardWidth = pageWidth / scorecardsPerRow - 2 * scorecardMargin;
 
   return [
     {
@@ -272,7 +320,7 @@ const scorecard = ({
           columnLabels(['', 'Scr', 'Result', 'Judge', 'Comp'], {
             alignment: 'center',
           }),
-          ...attemptRows(cutoff, attemptCount),
+          ...attemptRows(cutoff, attemptCount, scorecardWidth),
           [
             {
               text: 'Extra attempt',
@@ -315,7 +363,7 @@ const columnLabels = (labels, style = {}) =>
     text: label,
   }));
 
-const attemptRows = (cutoff, attemptCount) =>
+const attemptRows = (cutoff, attemptCount, scorecardWidth) =>
   times(attemptCount, attemptIndex => attemptRow(attemptIndex + 1)).reduce(
     (rows, attemptRow, attemptIndex) =>
       attemptIndex + 1 === attemptCount
@@ -324,13 +372,14 @@ const attemptRows = (cutoff, attemptCount) =>
             ...rows,
             attemptRow,
             attemptsSeparator(
-              cutoff && attemptIndex + 1 === cutoff.numberOfAttempts
+              cutoff && attemptIndex + 1 === cutoff.numberOfAttempts,
+              scorecardWidth
             ),
           ],
     []
   );
 
-const attemptsSeparator = cutoffLine => [
+const attemptsSeparator = (cutoffLine, scorecardWidth) => [
   {
     ...noBorder,
     colSpan: 5,
@@ -344,7 +393,7 @@ const attemptsSeparator = cutoffLine => [
                 type: 'line',
                 x1: 0,
                 y1: 0,
-                x2: (pageWidth - 4 * scorecardMargin) / 2,
+                x2: scorecardWidth,
                 y2: 0,
                 dash: { length: 5 },
               },

--- a/src/logic/wcif-extensions.js
+++ b/src/logic/wcif-extensions.js
@@ -31,7 +31,7 @@ const defaultExtensionData = {
     noTasksForNewcomers: false,
     tasksForOwnEventsOnly: false,
     printStations: false,
-    paperSize: 'a4',
+    scorecardPaperSize: 'a4',
   },
 };
 

--- a/src/logic/wcif-extensions.js
+++ b/src/logic/wcif-extensions.js
@@ -31,6 +31,7 @@ const defaultExtensionData = {
     noTasksForNewcomers: false,
     tasksForOwnEventsOnly: false,
     printStations: false,
+    paperSize: 'a4',
   },
 };
 


### PR DESCRIPTION
This prints a 1x1 grid of scorecards on each page, rather than a 2x2 grid on A4.

Attached are a sample of A6 scorecards from Oceanic Champs 2022 on A6:
[OC2022-scorecards.pdf](https://github.com/jonatanklosko/groupifier/files/9055096/OC2022-scorecards.pdf)

Fixes #13.