### PR TITLE
Add option to download scorecards for on-site registrations

### DIFF
--- a/src/components/Competition/PrintingManager/OTSScorecards/OTSScorecards.js
+++ b/src/components/Competition/PrintingManager/OTSScorecards/OTSScorecards.js
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import Button from '@material-ui/core/Button';
+import Checkbox from '@material-ui/core/Checkbox';
+import Grid from '@material-ui/core/Grid';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+
+import { downloadEmptyScorecardsForPersons } from '../../../../logic/documents/scorecards';
+import {
+  activityCodeToName,
+  competitorsRegisteredForAnEventWithoutGroups,
+} from '../../../../logic/activities';
+import languageInfo from '../../../../logic/translations';
+import { Avatar, ListItemAvatar } from '@material-ui/core';
+
+const OTSScorecards = ({ wcif }) => {
+  const missingScorecards = competitorsRegisteredForAnEventWithoutGroups(wcif);
+  const [selectedCompetitors, setSelectedCompetitors] = useState(
+    missingScorecards.map(c => c.person.wcaUserId)
+  );
+
+  const handleCompetitorClick = competitor => {
+    const id = competitor.person.wcaUserId;
+    setSelectedCompetitors(
+      selectedCompetitors.includes(id)
+        ? selectedCompetitors.filter(c => c !== id)
+        : [...selectedCompetitors, id]
+    );
+  };
+
+  const competitorSelected = competitor =>
+    selectedCompetitors.includes(competitor.person.wcaUserId);
+
+  const isSelectionEmpty = selectedCompetitors.length === 0;
+
+  const [language, setLanguage] = useState('en');
+
+  return (
+    <Paper style={{ padding: 16 }}>
+      <Grid container>
+        <Grid item xs={6}>
+          <Typography variant="subtitle1">Select persons</Typography>
+          <List style={{ width: 400 }}>
+            {missingScorecards.map(scorecards => (
+              <ListItem
+                key={scorecards.person.wcaUserId}
+                button
+                onClick={() => handleCompetitorClick(scorecards)}
+                style={
+                  missingScorecards.includes(scorecards) ? {} : { opacity: 0.5 }
+                }
+              >
+                <ListItemAvatar>
+                  <Avatar
+                    alt={scorecards.person.name}
+                    src={scorecards.person.avatar.thumbUrl}
+                  />
+                </ListItemAvatar>
+                <ListItemText
+                  primary={scorecards.person.name}
+                  secondary={scorecards.eventIds
+                    .map(eventId => activityCodeToName(`${eventId}-r1`))
+                    .join(', ')}
+                />
+                <Checkbox
+                  checked={competitorSelected(scorecards)}
+                  tabIndex={-1}
+                  disableRipple
+                  style={{ padding: 0 }}
+                />
+              </ListItem>
+            ))}
+          </List>
+        </Grid>
+      </Grid>
+      <Grid container spacing={2} style={{ marginTop: 16, marginBottom: 16 }}>
+        <Grid item xs={4}>
+          <FormControl variant="outlined" fullWidth>
+            <InputLabel>Scorecards language</InputLabel>
+            <Select
+              value={language}
+              onChange={e => setLanguage(e.target.value)}
+              label="Scorecards language"
+            >
+              {languageInfo.map(({ code, originalName, englishName }) => (
+                <MenuItem key={code} value={code}>
+                  {originalName === englishName
+                    ? originalName
+                    : `${originalName} (${englishName})`}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+      </Grid>
+      <Grid container spacing={1}>
+        <Grid item>
+          <Button
+            onClick={() =>
+              downloadEmptyScorecardsForPersons(
+                wcif,
+                selectedCompetitors,
+                language
+              )
+            }
+            disabled={isSelectionEmpty}
+          >
+            Scorecards
+          </Button>
+        </Grid>
+      </Grid>
+    </Paper>
+  );
+};
+
+export default OTSScorecards;

--- a/src/components/Competition/PrintingManager/OTSScorecards/OTSScorecards.js
+++ b/src/components/Competition/PrintingManager/OTSScorecards/OTSScorecards.js
@@ -46,7 +46,7 @@ const OTSScorecards = ({ wcif }) => {
     <Paper style={{ padding: 16 }}>
       <Grid container>
         <Grid item xs={6}>
-          <Typography variant="subtitle1">Select persons</Typography>
+          <Typography variant="subtitle1">Select competitors</Typography>
           <List style={{ width: 400 }}>
             {missingScorecards.map(scorecards => (
               <ListItem

--- a/src/components/Competition/PrintingManager/PrintingManager.js
+++ b/src/components/Competition/PrintingManager/PrintingManager.js
@@ -13,6 +13,7 @@ import {
   roundsMissingAssignments,
   activityCodeToName,
 } from '../../../logic/activities';
+import OTSScorecards from './OTSScorecards/OTSScorecards';
 
 const PrintingManager = ({ wcif }) => {
   const [tabValue, setTabValue] = useState(0);
@@ -49,11 +50,13 @@ const PrintingManager = ({ wcif }) => {
         <Tabs value={tabValue} onChange={(event, value) => setTabValue(value)}>
           <Tab label="Scorecards" />
           <Tab label="Competitor cards" />
+          <Tab label="OTS scorecards" />
         </Tabs>
       </Grid>
       <Grid item xs={12}>
         {tabValue === 0 && <Scorecards wcif={wcif} />}
         {tabValue === 1 && <CompetitorCards wcif={wcif} />}
+        {tabValue === 2 && <OTSScorecards wcif={wcif} />}
       </Grid>
       <Grid item>
         <Button

--- a/src/logic/activities.js
+++ b/src/logic/activities.js
@@ -302,8 +302,9 @@ export const roundsMissingScorecards = wcif =>
 export const competitorsRegisteredForAnEventWithoutGroups = wcif => {
   let persons = [];
   wcif.persons.forEach(person => {
-    if (!person.registration || person.registration?.status !== 'accepted')
+    if (!person.registration || person.registration?.status !== 'accepted') {
       return;
+    }
     person.registration.eventIds.forEach(eventId => {
       const hasCompetitorAssignment = person.assignments.some(
         a =>

--- a/src/logic/activities.js
+++ b/src/logic/activities.js
@@ -321,10 +321,6 @@ export const competitorsRegisteredForAnEventWithoutGroups = wcif => {
             p => p.person.wcaUserId === person.wcaUserId
           );
           newPerson.eventIds.push(eventId);
-          persons = persons.filter(
-            p => p.person.wcaUserId !== person.wcaUserId
-          );
-          persons.push(newPerson);
         }
       }
     });

--- a/src/logic/activities.js
+++ b/src/logic/activities.js
@@ -300,7 +300,7 @@ export const roundsMissingScorecards = wcif =>
     .filter(round => parseActivityCode(round.id).eventId !== '333fm');
 
 export const competitorsRegisteredForAnEventWithoutGroups = wcif => {
-  let persons = [];
+  let persons = {};
   wcif.persons.forEach(person => {
     if (!person.registration || person.registration?.status !== 'accepted')
       return;
@@ -313,22 +313,14 @@ export const competitorsRegisteredForAnEventWithoutGroups = wcif => {
           )
       );
       if (!hasCompetitorAssignment) {
-        if (!persons.some(p => p.person.wcaUserId === person.wcaUserId)) {
-          persons.push({ person, eventIds: [eventId] });
-        } else {
-          let newPerson = persons.find(
-            p => p.person.wcaUserId === person.wcaUserId
-          );
-          newPerson.eventIds.push(eventId);
-          persons = persons.filter(
-            p => p.person.wcaUserId !== person.wcaUserId
-          );
-          persons.push(newPerson);
+        if (!persons[person.wcaUserId]) {
+          persons[person.wcaUserId] = { person, eventIds: [] };
         }
+        persons[person.wcaUserId].eventIds.push(eventId);
       }
     });
   });
-  return persons;
+  return Object.values(persons);
 };
 
 export const allGroupsCreated = wcif =>

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -110,9 +110,9 @@ export const emptyScorecardsForPersons = (
     flatMap(eventIds, eventId => {
       const round = wcif.events
         .find(e => e.id === eventId)
-        ?.rounds?.find(r => r.id === `${eventId}-r1`);
-      const roundFormat = round?.format || '1';
-      const attemptCount = maxAttemptCountByFormat[roundFormat] || 5;
+        .rounds.find(r => r.id === `${eventId}-r1`);
+      const roundFormat = round.format;
+      const attemptCount = maxAttemptCountByFormat[roundFormat];
 
       const card = scorecard({
         competitionName: wcif.shortName,


### PR DESCRIPTION
Usually people who register on the spot are not assigned to any groups using Groupifier and it's necessary to write out blank scorecards for them. It would be useful to print these scorecards, just without group assigned, and this PR adds this functionality. 