### PR TITLE
Remove scramble checks for 555, 666, 777, minx

### DIFF
--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -363,7 +363,9 @@ const shouldPrintScrambleChecker = (competitor, round, wcif) => {
     printScrambleCheckerForTopRankedCompetitors,
     printScrambleCheckerForFinalRounds,
   } = getExtensionData('CompetitionConfig', wcif);
-
+  if (['555', '666', '777', 'minx'].includes(eventId)) {
+    return false;
+  }
   if (printScrambleCheckerForTopRankedCompetitors) {
     const singlePersonalBest = competitor.personalBests?.find(
       personalBest =>


### PR DESCRIPTION
After several competitions with scramble checks I came to the conclusion that scramble checks in 5x5x5, 6x6x6, 7x7x7 and Megaminx are effectively a waste of time. Many delegates on multiple competitions simply crossed them out in these events due to [Regulation 11i1e](https://www.worldcubeassociation.org/regulations/#11i1e) describing those events as an exception, as well as [Regulation 4g1a](https://www.worldcubeassociation.org/regulations/#4g1a) allowing for misscrambles at the discretion of the WCA Delegate. I've heard of people deliberately not using checks only because of these events being included in this feature.

This simple change removes scramble checks for events listed above, while letting them being used where it matters the most.