### PR TITLE
[codex] Fix later-round scorecard generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/jonatanklosko/groupifier.git"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "bin/bundle_fonts.sh && react-scripts build",
+    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
+    "build": "bin/bundle_fonts.sh && NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "postinstall": "bin/bundle_fonts.sh"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/jonatanklosko/groupifier.git"
   },
   "scripts": {
-    "start": "NODE_OPTIONS=--openssl-legacy-provider react-scripts start",
-    "build": "bin/bundle_fonts.sh && NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+    "start": "react-scripts start",
+    "build": "bin/bundle_fonts.sh && react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "postinstall": "bin/bundle_fonts.sh"

--- a/src/logic/activities.js
+++ b/src/logic/activities.js
@@ -295,9 +295,19 @@ export const roundsMissingAssignments = wcif =>
   );
 
 export const roundsMissingScorecards = wcif =>
-  roundsMissingResults(wcif)
+  flatMap(wcif.events, event => event.rounds)
+    .filter(round => roundNeedsScorecards(wcif, round))
     .filter(round => groupActivitiesAssigned(wcif, round.id))
     .filter(round => parseActivityCode(round.id).eventId !== '333fm');
+
+const roundNeedsScorecards = (wcif, round) => {
+  if (round.results.length === 0) {
+    const { roundNumber } = parseActivityCode(round.id);
+    return roundNumber === 1 || groupActivitiesAssigned(wcif, round.id);
+  }
+
+  return round.results.every(result => result.attempts.length === 0);
+};
 
 export const competitorsRegisteredForAnEventWithoutGroups = wcif => {
   let persons = {};

--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -281,7 +281,7 @@ const cutLine = properties => ({
   lineColor: '#888888',
 });
 
-const scorecards = (wcif, rounds, rooms, language) => {
+export const scorecards = (wcif, rounds, rooms, language) => {
   const {
     localNamesFirst,
     printOneName,
@@ -408,19 +408,64 @@ const isFinal = (round, wcif) => {
 };
 
 const groupActivitiesWithCompetitors = (wcif, roundId) => {
+  const sortedGroupActivities = hasDistributedAttempts(roundId)
+    ? groupActivitiesByRound(wcif, roundId)
+        /* Don't duplicate scorecards for each attempt.  */
+        .filter(
+          ({ activityCode }) =>
+            parseActivityCode(activityCode).attemptNumber === 1
+        )
+    : sortBy(
+        groupActivitiesByRound(wcif, roundId),
+        ({ activityCode }) => parseActivityCode(activityCode).groupNumber
+      );
   const sortedCompetitors = competitorsForRound(wcif, roundId);
+  const competitorOrderByRegistrantId = new Map(
+    (sortedCompetitors || []).map((competitor, index) => [
+      competitor.registrantId,
+      index,
+    ])
+  );
+  const assignedCompetitorsByGroup = sortedGroupActivities.map(
+    groupActivity => [
+      groupActivity,
+      wcif.persons
+        .filter(competitor =>
+          hasAssignment(competitor, groupActivity.id, 'competitor')
+        )
+        .map(competitor => [
+          competitor,
+          getAssignment(competitor, groupActivity.id, 'competitor'),
+        ])
+        .sort(([competitorA, assignmentA], [competitorB, assignmentB]) => {
+          const orderA =
+            competitorOrderByRegistrantId.get(competitorA.registrantId) ??
+            Number.MAX_SAFE_INTEGER;
+          const orderB =
+            competitorOrderByRegistrantId.get(competitorB.registrantId) ??
+            Number.MAX_SAFE_INTEGER;
+          if (orderA !== orderB) return orderA - orderB;
+          const stationA = assignmentA.stationNumber ?? Number.MAX_SAFE_INTEGER;
+          const stationB = assignmentB.stationNumber ?? Number.MAX_SAFE_INTEGER;
+          if (stationA !== stationB) return stationA - stationB;
+          return competitorA.name.localeCompare(competitorB.name);
+        })
+        .map(([competitor, assignment]) => [
+          competitor,
+          assignment.stationNumber,
+        ]),
+    ]
+  );
+
+  if (
+    assignedCompetitorsByGroup.some(
+      ([_, competitorsWithStation]) => competitorsWithStation.length > 0
+    )
+  ) {
+    return assignedCompetitorsByGroup;
+  }
+
   if (sortedCompetitors) {
-    const sortedGroupActivities = hasDistributedAttempts(roundId)
-      ? groupActivitiesByRound(wcif, roundId)
-          /* Don't duplicate scorecards for each attempt.  */
-          .filter(
-            ({ activityCode }) =>
-              parseActivityCode(activityCode).attemptNumber === 1
-          )
-      : sortBy(
-          groupActivitiesByRound(wcif, roundId),
-          ({ activityCode }) => parseActivityCode(activityCode).groupNumber
-        );
     return sortedGroupActivities.map(groupActivity => [
       groupActivity,
       sortedCompetitors
@@ -433,18 +478,18 @@ const groupActivitiesWithCompetitors = (wcif, roundId) => {
             .stationNumber,
         ]),
     ]);
-  } else {
-    /* If competitors for this round are not known yet, generate nameless scorecards. */
-    const expectedCompetitorCount = getExpectedCompetitorsByRound(wcif)[roundId]
-      .length;
-    const groupsWithSize = hasDistributedAttempts(roundId)
-      ? [[groupActivitiesByRound(wcif, roundId)[0], expectedCompetitorCount]]
-      : sortedGroupActivitiesWithSize(wcif, roundId, expectedCompetitorCount);
-    return groupsWithSize.map(([groupActivity, size]) => [
-      groupActivity,
-      times(size, () => [{ name: null, registrantId: null }, null]),
-    ]);
   }
+
+  /* If competitors for this round are not known yet, generate nameless scorecards. */
+  const expectedCompetitorCount = getExpectedCompetitorsByRound(wcif)[roundId]
+    .length;
+  const groupsWithSize = hasDistributedAttempts(roundId)
+    ? [[groupActivitiesByRound(wcif, roundId)[0], expectedCompetitorCount]]
+    : sortedGroupActivitiesWithSize(wcif, roundId, expectedCompetitorCount);
+  return groupsWithSize.map(([groupActivity, size]) => [
+    groupActivity,
+    times(size, () => [{ name: null, registrantId: null }, null]),
+  ]);
 };
 
 const blankScorecards = (wcif, language) => {

--- a/src/logic/tests/activities.test.js
+++ b/src/logic/tests/activities.test.js
@@ -1,0 +1,59 @@
+import {
+  Competition,
+  Event,
+  Round,
+  Venue,
+  Room,
+  Activity,
+  Person,
+} from './wcif-builders';
+import { roundsMissingScorecards } from '../activities';
+
+describe('roundsMissingScorecards', () => {
+  test('includes assigned later rounds even when their results are still empty', () => {
+    const round2Group = Activity({ activityCode: 'clock-r2-g1' });
+    const wcif = Competition({
+      events: [
+        Event({
+          id: 'clock',
+          rounds: [
+            Round({ id: 'clock-r1' }),
+            Round({ id: 'clock-r2', results: [] }),
+          ],
+        }),
+      ],
+      persons: [
+        Person({
+          registration: { eventIds: ['clock'] },
+          assignments: [
+            {
+              activityId: round2Group.id,
+              assignmentCode: 'competitor',
+              stationNumber: 1,
+            },
+          ],
+        }),
+      ],
+      schedule: {
+        venues: [
+          Venue({
+            rooms: [
+              Room({
+                activities: [
+                  Activity({
+                    activityCode: 'clock-r2',
+                    childActivities: [round2Group],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      },
+    });
+
+    expect(roundsMissingScorecards(wcif).map(round => round.id)).toContain(
+      'clock-r2'
+    );
+  });
+});

--- a/src/logic/tests/scorecards.test.js
+++ b/src/logic/tests/scorecards.test.js
@@ -1,0 +1,74 @@
+import {
+  Competition,
+  Event,
+  Round,
+  Venue,
+  Room,
+  Activity,
+  Person,
+} from './wcif-builders';
+import { setExtensionData } from '../wcif-extensions';
+import { scorecards } from '../documents/scorecards';
+
+describe('scorecards', () => {
+  test('uses assigned competitors for later rounds even when round results are empty', () => {
+    const round2Group = Activity({ activityCode: 'clock-r2-g1' });
+    const competitor = Person({
+      name: 'Clock Competitor',
+      registration: { eventIds: ['clock'] },
+      assignments: [
+        {
+          activityId: round2Group.id,
+          assignmentCode: 'competitor',
+          stationNumber: 1,
+        },
+      ],
+    });
+    const wcif = setExtensionData(
+      'CompetitionConfig',
+      Competition({
+        shortName: 'Example 2019',
+        events: [
+          Event({
+            id: 'clock',
+            rounds: [Round({ id: 'clock-r1' }), Round({ id: 'clock-r2' })],
+          }),
+        ],
+        persons: [competitor],
+        schedule: {
+          venues: [
+            Venue({
+              rooms: [
+                Room({
+                  activities: [
+                    Activity({
+                      activityCode: 'clock-r2',
+                      childActivities: [round2Group],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        },
+      }),
+      {
+        localNamesFirst: false,
+        printOneName: false,
+        printStations: true,
+        scorecardPaperSize: 'a4',
+        scorecardOrder: 'natural',
+        printScorecardsCoverSheets: false,
+      }
+    );
+
+    const cards = scorecards(
+      wcif,
+      [wcif.events[0].rounds[1]],
+      [wcif.schedule.venues[0].rooms[0]],
+      'en'
+    );
+
+    expect(JSON.stringify(cards)).toContain('Clock Competitor');
+  });
+});


### PR DESCRIPTION
## What changed

This PR was generated entirely by AI assistance.

It fixes later-round scorecard generation when a round already has competitor assignments but the WCIF does not yet have populated result scaffolding for that round.

The functional changes are:

- treat later rounds with existing assignments but empty `results` arrays as needing scorecards
- generate later-round scorecards from actual `persons[].assignments` when those assignments exist, instead of falling back to blank nameless cards
- add regression tests covering assigned later rounds with empty results

## Why these code changes were needed

### `src/logic/activities.js`

`roundsMissingScorecards()` now evaluates all rounds through a small helper instead of relying on `roundsMissingResults()`.

I made that change because `roundsMissingResults()` was too narrow for this case. A later round can already have assignments and still have an empty `results` array. In that state, we still want the round to show up as scorecard-ready.

The new helper keeps the rule explicit:

- first rounds with no results still need scorecards
- later rounds with no results also need scorecards if they already have group assignments
- rounds with result rows but no attempts still need scorecards as before

### `src/logic/documents/scorecards.js`

`groupActivitiesWithCompetitors()` now builds the group list before deciding whether it can derive competitors from results.

I made that change because the old flow only had one source of truth for later rounds: `competitorsForRound()`. That works when the WCIF already has the expected round/result scaffolding, but it fails when assignments exist before those result rows are populated.

The new flow adds a second path:

- gather the round's group activities first
- look directly at `wcif.persons[].assignments` for competitor assignments in each group
- if assignments exist, use them to build scorecards
- if assignments do not exist, keep the previous fallback behavior that generates nameless placeholder scorecards

That is why the diff in `scorecards.js` is larger than a simple condition change. This fix needed a real assignment-based path, not just a different boolean.

The direct assignment path also sorts competitors in a stable order. It prefers known round ordering when available, then station number, then name. I added that so printing stays consistent and readable even when round rankings are not available yet.

`scorecards()` is now exported so the regression test can exercise the actual scorecard-generation path directly.

## Impact

- assigned later rounds show up as scorecard-ready
- scorecards for those rounds include competitor names and stations when assignments are present
- rounds with no known competitor assignments still fall back to nameless placeholder scorecards as before

## Validation

- `yarn test --watch=false --runInBand src/logic/tests/activities.test.js src/logic/tests/scorecards.test.js src/logic/tests/competitors.test.js src/components/App/App.test.js src/components/Header/Header.test.js src/components/CompetitionList/CompetitionList.test.js src/logic/tests/formatters.test.js`
