### PR TITLE
Don't show scrambler checker box when the competitor's nationalRanking equals 0

### DIFF
--- a/src/logic/documents/scorecards.js
+++ b/src/logic/documents/scorecards.js
@@ -470,7 +470,8 @@ const shouldPrintScrambleChecker = (competitor, round, wcif) => {
       (singlePersonalBest && singlePersonalBest.worldRanking <= 50) ||
       (averagePersonalBest &&
         (averagePersonalBest.worldRanking <= 50 ||
-          averagePersonalBest.nationalRanking <= 15))
+          (averagePersonalBest.nationalRanking <= 15 &&
+            averagePersonalBest.nationalRanking > 0)))
     ) {
       return true;
     }


### PR DESCRIPTION
This will happen if the competitor switches nationality and haven't achieved PRs under new country yet, see [example](https://www.worldcubeassociation.org/persons/2022MORL01)

```
{
  "name": "Axel Morley",
  "wcaUserId": 186124,
  "wcaId": "2022MORL01",
  "registrantId": 19,
  "countryIso2": "FR",
  "gender": "m",
  "personalBests": [
    {
      "eventId": "333oh",
      "best": 2178,
      "worldRanking": 9967,
      "continentalRanking": 2567,
      "nationalRanking": 0,
      "type": "average"
    }
  ]
}
````